### PR TITLE
🔒 Remove usage of __proto__

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function gm (source, height, color) {
   EventEmitter.call(this);
 
   this._options = {};
-  this.options(this.__proto__._options);
+  this.options(Object.getPrototypeOf(this)._options);
 
   this.data = {};
   this._in = [];
@@ -103,7 +103,7 @@ gm.subClass = function subClass (options) {
     parent.call(this, source, height, color);
   }
 
-  gm.prototype.__proto__ = parent.prototype;
+  Object.setPrototypeOf(gm.prototype, parent.prototype)
   gm.prototype._options = {};
   gm.prototype.options(options);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reedsy/gm",
   "description": "GraphicsMagick and ImageMagick for node.js",
-  "version": "1.25.0-reedsy-1.0.0",
+  "version": "1.25.0-reedsy-1.0.1",
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
   "keywords": [
     "graphics",
@@ -29,7 +29,7 @@
   "main": "./index",
   "scripts": {
     "security": "npm audit",
-    "test": "npm run security && npm run test-integration",
+    "test": "npm run security && NODE_OPTIONS=\"--disable-proto=throw\" npm run test-integration",
     "test-integration": "node test/ --integration",
     "test-unit": "node test/"
   },


### PR DESCRIPTION
gm at the moment throws when trying to convert the image, because we changed the option in the images API to thrown when `__proto__` is used. More info:
- https://github.com/reedsy/reedsy-editor-images-api/pull/528

Depends on:
---
- https://github.com/reedsy/gm/pull/3